### PR TITLE
Added color support for azure sign in button

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ If you're running Discourse from the Docker container, add these environment var
 * DISCOURSE_AZURE_CLIENT_SECRET
 * (optional) DISCOURSE_AZURE_TENANT_ID
 * (optional) DISCOURSE_AZURE_TITLE
+* (optional) DISCOURSE_AZURE_COLOR
+
 
 Or if you're not using Docker add the following to your `discourse.conf` file:
 
 * azure_client_id
 * azure_client_secret
 * (optional) azure_title
+* (optional) azure_color

--- a/plugin.rb
+++ b/plugin.rb
@@ -52,10 +52,11 @@ end
 
 title = GlobalSetting.try(:azure_title) || "Azure AD"
 button_title = GlobalSetting.try(:azure_title) || "with Azure AD"
+color = GlobalSetting.try(:azure_color) || '#33ccff'
 
 auth_provider :title => button_title,
               :authenticator => AzureOAuth2Authenticator.new('azure_oauth2'),
               :message => "Authorizing with #{title} (make sure pop up blockers are not enabled)",
               :frame_width => 725,
               :frame_height => 500,
-              :background_color => '#71B1D1'
+              :background_color => color


### PR DESCRIPTION
Needed this feature as grey was not clear with the theme we chose . Any person can change color based on theme they chose . 